### PR TITLE
Add publishable npm package for Geist common messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /Cargo.lock
+dist/

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
     "name": "@geist/common",
     "author": "Faust Computer",
     "version": "0.1.2",
-    "main": "./dist/main.js",
-    "types": "./dist/main.d.ts",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
     "files": [
         "/dist"
     ],

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+    "name": "@geist/common",
+    "author": "Faust Computer",
+    "version": "0.1.2",
+    "main": "./dist/main.js",
+    "types": "./dist/main.d.ts",
+    "files": [
+        "/dist"
+    ],
+    "license": "MIT",
+    "dependencies": {
+        "typescript": "^4.9.5"
+    },
+    "description": "Geist common messages for running a Geist application"
+}

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-    "name": "@geist/common",
+    "name": "geist_common",
     "author": "Faust Computer",
     "version": "0.1.2",
-    "main": "./dist/index.js",
-    "types": "./dist/index.d.ts",
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
     "files": [
         "/dist"
     ],

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,240 @@
+/* eslint-disable */
+export interface IGeistMsgsContractOpMode {
+  mode: number;
+}
+
+export enum IGeistMsgsContractOpModeConst {
+  GET = 0,
+  SET = 1,
+}
+
+export interface IGeistMsgsDacMachineData {
+  header: IStdMsgsHeader;
+  co2_captured: number;
+  total_kwh_used: number;
+}
+
+export interface IGeistMsgsGpsData {
+  header: IStdMsgsHeader;
+  latitude: number;
+  longitude: number;
+  altitude: number;
+}
+
+export interface IGeistMsgsInputs {
+  key: string;
+  value: string;
+}
+
+export interface IGeistSrvContractCallRequest {
+  header: IStdMsgsHeader;
+  path: string;
+  address: string;
+  method: string;
+  chain_id: number;
+  inputs: IGeistMsgsInputs[];
+  op: IGeistMsgsContractOpMode;
+  output: string;
+}
+
+export interface IGeistSrvContractCallResponse {
+  success: boolean;
+  tx_hash: string;
+  error: string;
+}
+
+export interface IGeistSrvCreateProofRequest {
+  path: string;
+  proof_type: number;
+}
+
+export interface IGeistSrvCreateProofResponse {
+  success: boolean;
+  proof: string;
+  error: string;
+}
+
+export interface IGeistSrvEthTransferRequest {
+  header: IStdMsgsHeader;
+  author: string;
+  to: string;
+  amount: number;
+  gas: number;
+  chain_id: number;
+  gas_price: number;
+  value: number;
+  data: string;
+}
+
+export interface IGeistSrvEthTransferResponse {
+  success: boolean;
+  tx_hash: string;
+  error: string;
+}
+
+export interface IGeistSrvHelloWorldResponse {
+  success: boolean;
+  message: string;
+}
+
+export interface IGeistSrvRecordTopicDataRequest {
+  topic: string;
+  topic_msg_type: string;
+  duration: number;
+  target_path: string;
+  max_record_count: number;
+  storage_medium: number;
+}
+
+export interface IGeistSrvRecordTopicDataResponse {
+  success: boolean;
+  message: string;
+}
+
+export interface IGeistSrvSnapshotTopicDataRequest {
+  file_path: string;
+  topic_name: string;
+}
+
+export interface IGeistSrvSnapshotTopicDataResponse {
+  success: boolean;
+}
+
+export interface IGeistSrvWhoAmIResponse {
+  success: boolean;
+  version: string;
+}
+
+export interface IStdMsgsBool {
+  data: boolean;
+}
+
+export interface IStdMsgsByte {
+  data: number;
+}
+
+export interface IStdMsgsByteMultiArray {
+  layout: IStdMsgsMultiArrayLayout;
+  data: number[];
+}
+
+export interface IStdMsgsChar {
+  data: number;
+}
+
+export interface IStdMsgsColorRgba {
+  r: number;
+  g: number;
+  b: number;
+  a: number;
+}
+
+export interface IStdMsgsFloat32 {
+  data: number;
+}
+
+export interface IStdMsgsFloat32MultiArray {
+  layout: IStdMsgsMultiArrayLayout;
+  data: number[];
+}
+
+export interface IStdMsgsFloat64 {
+  data: number;
+}
+
+export interface IStdMsgsFloat64MultiArray {
+  layout: IStdMsgsMultiArrayLayout;
+  data: number[];
+}
+
+export interface IStdMsgsHeader {
+  stamp: { sec: number, nanosec: number };
+  frame_id: string;
+}
+
+export interface IStdMsgsInt16 {
+  data: number;
+}
+
+export interface IStdMsgsInt16MultiArray {
+  layout: IStdMsgsMultiArrayLayout;
+  data: number[];
+}
+
+export interface IStdMsgsInt32 {
+  data: number;
+}
+
+export interface IStdMsgsInt32MultiArray {
+  layout: IStdMsgsMultiArrayLayout;
+  data: number[];
+}
+
+export interface IStdMsgsInt64 {
+  data: number;
+}
+
+export interface IStdMsgsInt64MultiArray {
+  layout: IStdMsgsMultiArrayLayout;
+  data: number[];
+}
+
+export interface IStdMsgsInt8 {
+  data: number;
+}
+
+export interface IStdMsgsInt8MultiArray {
+  layout: IStdMsgsMultiArrayLayout;
+  data: number[];
+}
+
+export interface IStdMsgsMultiArrayDimension {
+  label: string;
+  size: number;
+  stride: number;
+}
+
+export interface IStdMsgsMultiArrayLayout {
+  dim: IStdMsgsMultiArrayDimension[];
+  data_offset: number;
+}
+
+export interface IStdMsgsString {
+  data: string;
+}
+
+export interface IStdMsgsUInt16 {
+  data: number;
+}
+
+export interface IStdMsgsUInt16MultiArray {
+  layout: IStdMsgsMultiArrayLayout;
+  data: number[];
+}
+
+export interface IStdMsgsUInt32 {
+  data: number;
+}
+
+export interface IStdMsgsUInt32MultiArray {
+  layout: IStdMsgsMultiArrayLayout;
+  data: number[];
+}
+
+export interface IStdMsgsUInt64 {
+  data: number;
+}
+
+export interface IStdMsgsUInt64MultiArray {
+  layout: IStdMsgsMultiArrayLayout;
+  data: number[];
+}
+
+export interface IStdMsgsUInt8 {
+  data: number;
+}
+
+export interface IStdMsgsUInt8MultiArray {
+  layout: IStdMsgsMultiArrayLayout;
+  data: number[];
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "compilerOptions": {
+      "module": "commonjs",
+      "target": "es2019",
+      "declaration": true,
+      "outDir": "./dist"
+    },
+    "include": [
+      "src/**/*"
+    ]
+  }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,6 @@
       "outDir": "./dist"
     },
     "include": [
-      "src/**/*"
+      "./src/index.ts"
     ]
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,6 @@
       "outDir": "./dist"
     },
     "include": [
-      "./src/index.ts"
+      "src/index.ts"
     ]
   }


### PR DESCRIPTION
## Motivation
We want to make it as easy as possible for devs to build on our platform.

## Description
- [x] Add config and package details
- [x] Build enums and types for msgs in common
- [x] Publish package on npm

## How this has been tested?
In a local dev environment